### PR TITLE
Use matplotlib default fig and label sizes (address #26, #27)

### DIFF
--- a/trendvis/gridclass.py
+++ b/trendvis/gridclass.py
@@ -26,11 +26,13 @@ class Grid(object):
             [True|False].  Indicates if x is the main axis.  Determines
             some attributes
         figsize : tuple of ints or floats
-            Default (10, 10).  The figure dimensions in inches
+            The figure dimensions in inches. If None, defaults to matplotlib
+            rc figure.figsize.
         **kwargs
             Any plt.figure arguments
 
         """
+        figsize = figsize or plt.rcParams['figure.figsize']
         self.fig = plt.figure(figsize=figsize)
 
         self.gridrows, self.yratios = self._ratios_arelists(yratios)

--- a/trendvis/tests/test_trendvis.py
+++ b/trendvis/tests/test_trendvis.py
@@ -16,6 +16,9 @@ import matplotlib.pyplot as plt
 from matplotlib.testing.noseclasses import KnownFailure
 from nose.tools import assert_equal, assert_raises, assert_false, assert_true
 
+# baseline images use the old default figsize of 10x10 inches.
+plt.rcParams['figure.figsize'] = '10, 10'
+
 
 @cleanup
 def test_xgrid_init():

--- a/trendvis/xgrid_ystack.py
+++ b/trendvis/xgrid_ystack.py
@@ -641,7 +641,7 @@ class XGrid(Grid):
             kwargs.update(transform=low_ax.transAxes)
             low_ax.plot(left, lower_y, **kwargs)
 
-    def set_ylabels(self, ylabels, fontsize=14, labelpad=12, **kwargs):
+    def set_ylabels(self, ylabels, fontsize=None, labelpad=12, **kwargs):
         """
         Tool for setting all y axis labels at once.  Can skip labelling an axis
         by providing a ``None`` in corresponding position in list.
@@ -652,7 +652,7 @@ class XGrid(Grid):
             The list of labels, one per y-axis.  Insert ``None`` in list to
             skip an axis.
         fontsize : int
-            Default 14.  The font size of ``ylabels``
+            Default None. The font size of ``ylabels``
         labelpad : int
             Default 12.  The spacing between the tick labels and the axis
             labels.

--- a/trendvis/xgrid_ystack.py
+++ b/trendvis/xgrid_ystack.py
@@ -10,7 +10,7 @@ class XGrid(Grid):
 
     """
 
-    def __init__(self, ystack_ratios, xratios=1, figsize=(10, 10),
+    def __init__(self, ystack_ratios, xratios=1, figsize=None,
                  startside='left', alternate_sides=True,
                  onespine_forboth=False, **kwargs):
         """
@@ -25,7 +25,8 @@ class XGrid(Grid):
             Default 1. The relative sizes of the main axis column(s).
             Not directly comparable to ``ystack_ratios``
         figsize : tuple of ints or floats
-            Default (10,10).  The figure dimensions in inches
+            Default None. The figure dimensions in inches.
+            If not provided, defaults to matplotlib rc figure.figsize.
         startside : string
             Default 'left'.  ['left'|'right'].  The side the topmost y axis
             will be on.

--- a/trendvis/ygrid_xstack.py
+++ b/trendvis/ygrid_xstack.py
@@ -641,7 +641,7 @@ class YGrid(Grid):
             kwargs.update(transform=r_ax.transAxes)
             r_ax.plot(right_x, upper, **kwargs)
 
-    def set_xlabels(self, xlabels, fontsize=14, labelpad=12, **kwargs):
+    def set_xlabels(self, xlabels, fontsize=None, labelpad=12, **kwargs):
         """
         Tool for setting all x axis labels at once. Can skip labelling an axis
         by providing a ``None`` in corresponding poiition in list.
@@ -652,7 +652,7 @@ class YGrid(Grid):
             The list of labels, one per x-axis.  Insert ``None`` in list to
             skip an axis.
         fontsize : int
-            Default 14.  The fontsize of ``xlabels``
+            Default None. The font size of ``xlabels``
         labelpad : int
             Default 12.  The spacing between the tick labels adn the axis
             labels.

--- a/trendvis/ygrid_xstack.py
+++ b/trendvis/ygrid_xstack.py
@@ -10,7 +10,7 @@ class YGrid(Grid):
 
     """
 
-    def __init__(self, xstack_ratios, yratios=1, figsize=(10, 10),
+    def __init__(self, xstack_ratios, yratios=1, figsize=None,
                  startside='top', alternate_sides=True,
                  onespine_forboth=False, **kwargs):
         """
@@ -25,7 +25,8 @@ class YGrid(Grid):
             Default 1.  The relative sizes of the main axis row(s).
             Not directly comparable to ``xstack_ratios``
         figsize : tuple of ints or floats
-            Default (10, 10).  The figure dimensions in inches
+            Default None. The figure dimensions in inches.
+            If not provided, defaults to matplotlib rc figure.figsize.
         startside : string
             Default 'top'.  ['top'|'bottom'].  The side the leftmost x axis
             will be on.


### PR DESCRIPTION
I reset the default figure and label sizes to matplotlib's default. I also told the test script to use the a default figure size of 10x10 inches so that it is compatible with previous test results. Please have a look and feel free to review!